### PR TITLE
fix: remove hardcoded zoom-out limit of 1600 units

### DIFF
--- a/NASSCAD_V4_2_7_AIO.htm
+++ b/NASSCAD_V4_2_7_AIO.htm
@@ -5886,7 +5886,7 @@ function mDblClick(e){
     cotVisible=false; _rotMode=false; _camLast.objSig='';
   }
 }
-function mWheel(e){e.preventDefault();camA.dist=Math.max(5,Math.min(1600,camA.dist+e.deltaY*0.3));updCam();}
+function mWheel(e){e.preventDefault();camA.dist=Math.max(5,Math.min(cam.far,camA.dist+e.deltaY*0.3));updCam();}
 function onRz(){const vp=document.getElementById('vp');cam.aspect=vp.clientWidth/vp.clientHeight;cam.updateProjectionMatrix();ren.setSize(vp.clientWidth,vp.clientHeight);cotCanvas.width=vp.clientWidth;cotCanvas.height=vp.clientHeight;_camDirty=true;}
 
 // ═══════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem

The scroll-wheel zoom handler had a hardcoded max camera distance of **1600 units** (), which prevented users from zooming out far enough to see large objects (e.g. several meters across when importing STP files).

## Fix

Replaced the hardcoded  with  (20000) so the zoom range matches the camera's far clip plane.

**Before:**
```js
camA.dist = Math.max(5, Math.min(1600, camA.dist + e.deltaY * 0.3));
```

**After:**
```js
camA.dist = Math.max(5, Math.min(cam.far, camA.dist + e.deltaY * 0.3));
```

## Why this approach

- Using `cam.far` instead of a magic number keeps the zoom limit in sync with the camera's render distance
- The camera's far clip plane was already set to `20000`, so the rendering pipeline handles these distances fine
- Minimal change — only modifies one function

Fixes #3